### PR TITLE
setup: WARP.md, workspace scaffolding, and CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Code owners are automatically requested for review on PRs that modify matching paths.
+# Global default owner for all files in this repo:
+* @Marcus-Murray

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Run workspace tests
+        run: npm -ws run test

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,48 @@
+# WARP.md
+
+This file provides guidance to WARP (warp.dev) when working with code in this repository.
+
+Project overview
+- Superapp Studio is a TypeScript monorepo scaffold targeting a tablet‑first “superapp” that blends Figma‑like ideation, Notion‑like docs/tasks/PM, and AI code generation. Target device: Samsung S10 FE+ (Android). Cross‑platform foundation with npm workspaces.
+- Workspace layout (planned):
+  - apps/ — end‑user apps (mobile first; web/desktop later)
+  - packages/ — shared libraries (ui, core, ai, sync, schema, tooling)
+  - docs/ — design vision, architecture, roadmap
+
+Requirements
+- Node.js >= 18 (enforced via package.json engines)
+- npm workspaces enabled (npm v7+)
+
+Common commands
+- Install all workspace dependencies (run at repo root):
+  - PowerShell: npm install
+
+- Build, Lint, Format, Test (repo root):
+  - Current scripts are placeholders:
+    - npm run build → "No build yet"
+    - npm run lint → "No lint yet"
+    - npm run format → "No format yet"
+    - npm test → "No tests yet"
+  - Once apps/packages provide scripts, prefer running them per‑workspace (see below).
+
+- Run a script in a specific workspace (examples):
+  - App dev: npm run -w .\apps\ideation-app dev
+  - App tests: npm run -w .\apps\ideation-app test
+  - Core package tests: npm run -w .\packages\core test
+  - Across all workspaces: npm run -ws build
+
+- Running a single test (Node's built-in test runner is configured):
+  - By name (core): npm run -w .\packages\core test -- --test-name-pattern "hello"
+  - By name (app): npm run -w .\apps\ideation-app test -- --test-name-pattern "app can import"
+  - By file (core): npm run -w .\packages\core test -- test\hello.test.js
+
+High-level architecture and workflow
+- Monorepo with npm workspaces:
+  - apps/* consume shared packages from packages/*.
+  - packages/* house cross‑cutting concerns (ui components, core domain logic, AI orchestration, sync/transport, schema/validation, tooling).
+  - docs/ captures design/architecture/roadmap context informing implementation in apps/ and packages/.
+- Dependency flow (intended): packages → apps (one‑way). Apps compose features by importing from shared packages. Workspaces are versioned internally and linked by npm during install.
+
+Notes derived from README
+- The repository is currently scaffolded. After creating apps/ and packages/, re‑run npm install to link workspaces.
+- Vision: sketch/wireframe on tablet, auto‑sync to AI pipeline that generates boilerplates, manage projects/docs/tasks within the same app, resume on PC with ready‑to‑run repos.

--- a/apps/ideation-app/package.json
+++ b/apps/ideation-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ideation-app",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "build": "node -e \"console.log('build ok: ideation-app')\"",
+    "dev": "node src/index.js",
+    "test": "node --test",
+    "lint": "node -e \"console.log('lint ok: ideation-app')\"",
+    "format": "node -e \"console.log('format ok: ideation-app')\""
+  },
+  "engines": { "node": ">=18" },
+  "dependencies": {
+    "@superapp/core": "0.0.1"
+  }
+}

--- a/apps/ideation-app/src/index.js
+++ b/apps/ideation-app/src/index.js
@@ -1,0 +1,3 @@
+import { hello } from '@superapp/core';
+
+console.log(hello('Ideation'));

--- a/apps/ideation-app/test/smoke.test.js
+++ b/apps/ideation-app/test/smoke.test.js
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { hello } from '@superapp/core';
+
+test('app can import @superapp/core', () => {
+  assert.equal(typeof hello, 'function');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,44 @@
+{
+  "name": "superapp-studio",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "superapp-studio",
+      "version": "0.1.0",
+      "license": "MIT",
+      "workspaces": [
+        "apps/*",
+        "packages/*"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/ideation-app": {
+      "version": "0.0.1",
+      "dependencies": {
+        "@superapp/core": "0.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@superapp/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/ideation-app": {
+      "resolved": "apps/ideation-app",
+      "link": true
+    },
+    "packages/core": {
+      "name": "@superapp/core",
+      "version": "0.0.1",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@superapp/core",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.js",
+  "exports": "./src/index.js",
+  "scripts": {
+    "build": "node -e \"console.log('build ok: @superapp/core')\"",
+    "dev": "node src/index.js",
+    "test": "node --test",
+    "lint": "node -e \"console.log('lint ok: @superapp/core')\"",
+    "format": "node -e \"console.log('format ok: @superapp/core')\""
+  },
+  "engines": { "node": ">=18" }
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,0 +1,3 @@
+export function hello(name = 'world') {
+  return `Hello, ${name}!`;
+}

--- a/packages/core/test/hello.test.js
+++ b/packages/core/test/hello.test.js
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { hello } from '../src/index.js';
+
+test('hello returns greeting', () => {
+  assert.equal(hello('Superapp'), 'Hello, Superapp!');
+});


### PR DESCRIPTION
This PR adds:

- WARP.md with repository-specific guidance for Warp
- Minimal npm workspaces: packages/core and apps/ideation-app (Node 18+, Node test runner)
- GitHub Actions CI workflow to run tests on push/PR

Also aligns npm workspace linking using plain semver for @superapp/core in the app.\n\nAfter merge, the default developer commands in WARP.md are copy/pasteable for this repo.